### PR TITLE
added ability for bot to listen to requests from website

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,5 @@
-discord
-requests
+aiohttp==3.7.2
+discord==1.0.1
+eventemitter==0.2.0
+nest-asyncio==1.4.2
+requests==2.24.0

--- a/webhooklistener.py
+++ b/webhooklistener.py
@@ -1,0 +1,28 @@
+from aiohttp import web
+from eventemitter import EventEmitter
+
+
+class WebHookListener(EventEmitter):
+
+    async def start(self):
+        app = web.Application()
+        app.add_routes(routes)
+        runner = web.AppRunner(app)
+        await runner.setup()
+        site = web.TCPSite(runner, '0.0.0.0', 8080)
+        await site.start()
+
+
+listener = WebHookListener()
+
+routes = web.RouteTableDef()
+
+
+@routes.get('/')
+async def get_root(req):
+    listener.emit('get')
+
+
+@routes.post('/')
+async def post_root(req):
+    listener.emit('post', await req.json())


### PR DESCRIPTION
No added functionality in this pull request, this only stages us for future added functionality.

Added the ability for the bot to listen to and take action upon receipt of http requests. The bot will listen on port 8080, the docker-compose should be altered to put nginx on the bot network and an nginx config change will be needed to allow requests to flow through, I will create a separate pull request for that.

Two more env variables are needed for the bot, SITE_TOKEN which will also be added to the backend, the backend will send that token in all its requests to validate.  The other is CHANNEL_NAME which is the channel in which anything the bot says as a result of these push notifications from the site will be said in. PopeUrban should decide what that is. Alternatively we can only allow it to send DMs to users, should be an easy change.

To work with this code in your own test environment is a bit tricky. In addition to having the proper env variables port 8080 needs to be open to allow the container to receive requests. The problem is that this is incompatible with network_mode: host. The workaround:

Switch from binding ports 8080:8080 to network mode: host depending on what you are testing. You need ports when testing the bot receiving requests, and you need network mode when testing the bot sending requests.

Once you've done all that, just uncomment the code to give the listener events and the functions it calls, currently lines 55-65 of discordbot.py. Then you can test with curl or postman or w/e.