### PR TITLE
update to debian-slim

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -1,18 +1,13 @@
-FROM python:3.8.0-alpine
+FROM python:3.9.1-slim-buster
 
-RUN addgroup -S app && adduser -S app -G app
+RUN useradd -ms /bin/bash app
 
 WORKDIR /usr/src/app
 
-RUN apk update \
-    && apk add \
+RUN apt-get -y update \
+    && apt-get -y install \
     gcc \
-    musl-dev \
-    python3-dev
-
-RUN apk update \
-    && apk add --no-cache \
-    bash 
+    netcat
 
 RUN pip install --upgrade pip \
     && pip install --upgrade wheel

--- a/dockerfile.dev
+++ b/dockerfile.dev
@@ -1,16 +1,11 @@
-FROM python:3.8.0-alpine
+FROM python:3.9.1-slim-buster
 
 WORKDIR /usr/src/app
 
-RUN apk update \
-    && apk add \
+RUN apt-get -y update \
+    && apt-get -y install \
     gcc \
-    musl-dev \
-    python3-dev
-
-RUN apk update \
-    && apk add --no-cache \
-    bash 
+    netcat
 
 RUN pip install --upgrade pip \
     && pip install --upgrade wheel


### PR DESCRIPTION
Alpine is apparently not a good choice for python images, updated dockerfile to debian with slim-buster which seems to be the recommended smallest image.